### PR TITLE
Correct batch-table sizing

### DIFF
--- a/batchtable.py
+++ b/batchtable.py
@@ -51,8 +51,9 @@ class BatchTable:
 
 		else:
 			self.batch_in = data_in
-
-		self.num_features = len(self.batch_in)
+		if len(self.batch_in):
+			first_key = self.batch_in.keys()[0]
+			self.num_features = len(self.batch_in[first_key])
 
 	def addGlobal(self, key, value):
 		self.batch_in[key] = value


### PR DESCRIPTION
It seems we should be counting the number of things associated with one key, rather than the number of keys.

h/t to @KevinCybura (who doesn't have write access).