### PR TITLE
i3dm Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GLTF to Binary GLTF (GLB) Converter
 
 Created by Christopher Mitchell, Ph.D. et alia of Geopipe, Inc.
 
-This project was inspired by https://github.com/Qantas94Heavy/binary-gltf-utils and started as a direct Javascript-to-Python port with a bunch of bugfixes. It implements `b3dm` headers for Cesium 3D Tiles, and will soon implement `i3dm` as well. It also includes a `packcmpt` tool for combining one or more `i3dm`/`b3dm` models into a single `cmpt` file.
+This project was inspired by https://github.com/Qantas94Heavy/binary-gltf-utils and started as a direct Javascript-to-Python port with a bunch of bugfixes. It can create both b3dm and i3dm files for Cesium 3D Tiles. It also includes a `packcmpt` tool for combining one or more `i3dm`/`b3dm` models into a single `cmpt` file.
 
 Usage
 -----
@@ -42,7 +42,21 @@ optional arguments:
   -o OUTPUT, --output OUTPUT    Output cmpt file
   -u                            Unpack the output CMPT file instead of creating it (incomplete)
 ```
+### i3dm ###
+```
+$ ./i3dm.py -h
+usage: usage: i3dm.py [-h] -i I3DM -g GLB -o OUTPUT
+
+Generate an i3dm file from JSON describing instances, and a GLB to instance
+
+required arguments:
+  -i, --i3dm					JSON for instance semantics
+  -g, --glb						Path to GLB file to instance
+  -o, --output					Path to i3dm file to output
+
+optional arguments:
+  -h, --help                    show this help message and exit
 
 License
 -------
-(c) 2016-2018 Geopipe, Inc. and licensed under the BSD 3-Clause license. See LICENSE.
+(c) 2016-2019 Geopipe, Inc. and licensed under the BSD 3-Clause license. See LICENSE.

--- a/b3dm.py
+++ b/b3dm.py
@@ -124,3 +124,9 @@ class B3DM:
 		calc_len = struct.calcsize(fmt)
 		self.offset += calc_len
 		return struct.unpack(fmt, data[self.offset - calc_len : self.offset])[0]
+
+def main():
+	raise NotImplementedError("This file cannot be used directly!")
+
+if __name__ == "__main__":
+	main()

--- a/batchtable.py
+++ b/batchtable.py
@@ -87,3 +87,20 @@ class BatchTable:
 
 	def getNumFeatures(self):
 		return self.num_features
+
+	""" A few utiities """
+	def nestedListToBin(self, val, val_type):
+		if type(val) is list:
+			output = bytearray()
+			for item in val:
+				output.extend(self.nestedListToBin(item, val_type))
+			return output
+		else:
+			if val_type == 'f32':
+				return struct.pack('<f', val)
+			elif val_type == 'u16':
+				return struct.pack('<H', val)
+			else:
+				raise TypeError("Don't know how to pack type '%s'" % val_type)
+
+	

--- a/batchtable.py
+++ b/batchtable.py
@@ -2,7 +2,7 @@
 
 #--------------------------------------------------
 # batchtable.py: Component of GLTF to GLB converter
-# (c) 2016 Geopipe, Inc.
+# (c) 2016 - 2019 Geopipe, Inc.
 # All rights reserved. See LICENSE.
 #--------------------------------------------------
 
@@ -37,6 +37,8 @@ class BatchTable:
 		if object_wise:
 			n_objs = len(data_in)
 			# Find all the fields for all the objects
+			if type(data_in) is list:
+				data_in = {i: data_in[i] for i in xrange(len(data_in))}
 			for obj, objval in data_in.iteritems():
 				obj = int(obj)
 
@@ -55,17 +57,16 @@ class BatchTable:
 			first_key = self.batch_in.keys()[0]
 			self.num_features = len(self.batch_in[first_key])
 
-	def addGlobal(self, key, value):
-		self.batch_in[key] = value
-		self.num_features += 1
-
 	def writeOutput(self):
 		data_out = {}
 		# TODO: Add proper encoding to JSON + binary, rather than just
 		# punting to the naive method
 		data_out = self.batch_in
 		self.batch_json = bytearray(json.dumps(data_out, separators=(',', ':'), sort_keys=True))
+
+		# TODO: Why do we clear this?
 		self.batch_in = bytearray()
+		self.num_features = 0
 
 	def finalize(self):
 		# Create the actual batch JSON (and binary)

--- a/featuretable.py
+++ b/featuretable.py
@@ -3,7 +3,7 @@
 #--------------------------------------------------
 # featuretable.py: Component of GLTF to GLB converter
 # Currently a placeholder copy of BatchTable
-# (c) 2017 Geopipe, Inc.
+# (c) 2017 - 2019 Geopipe, Inc.
 # All rights reserved. See LICENSE.
 #--------------------------------------------------
 
@@ -14,3 +14,43 @@ from batchtable import BatchTable
 class FeatureTable(BatchTable):
 	def __init__(self):
 		BatchTable.__init__(self)
+		self.features_global = {}
+		self.features_json = bytearray()
+		self.features_bin  = bytearray()
+		self.num_global_features = 0
+
+	def addGlobal(self, key, value):
+		self.features_global[key] = value
+		self.num_global_features += 1
+
+	def writeOutput(self):
+		data_out = {}
+		# TODO: Add proper encoding to JSON + binary, rather than just
+		# punting to the naive method
+		data_out = self.batch_in
+		data_out.update(self.features_global)
+		print data_out
+		self.features_json = bytearray(json.dumps(data_out, separators=(',', ':'), sort_keys=True))
+		
+		# TODO: Why do we clear these?
+		self.batch_in = bytearray()
+		self.features_global = bytearray()
+		self.num_features = 0
+		self.num_global_features = 0
+
+	def finalize(self):
+		# Create the actual features JSON (and binary)
+		self.writeOutput()
+
+		# Pad with spaces to a multiple of 4 bytes
+		padded_features_json_len = len(self.features_json) + 3 & ~3
+		self.features_json.extend(' ' * (padded_features_json_len - len(self.features_json)))
+
+		padded_features_bin_len = len(self.features_bin) + 3 & ~3
+		self.features_bin.extend(' ' * (padded_features_bin_len - len(self.features_bin)))
+
+	def getFeatureJSON(self):
+		return self.features_json
+
+	def getFeatureBin(self):
+		return self.features_bin

--- a/featuretable.py
+++ b/featuretable.py
@@ -27,9 +27,9 @@ class FeatureTable(BatchTable):
 		data_out = {}
 		# TODO: Add proper encoding to JSON + binary, rather than just
 		# punting to the naive method
-		data_out = self.batch_in
-		data_out.update(self.features_global)
-		print data_out
+		data_out = self.features_global
+		data_out.update(self.batch_in)
+		
 		self.features_json = bytearray(json.dumps(data_out, separators=(',', ':'), sort_keys=True))
 		
 		# TODO: Why do we clear these?

--- a/gltf2glb.py
+++ b/gltf2glb.py
@@ -2,7 +2,7 @@
 
 #------------------------------------
 # gltf2glb.py: GLTF to GLB converter
-# (c) 2016 Geopipe, Inc.
+# (c) 2016 - 2019 Geopipe, Inc.
 # All rights reserved. See LICENSE.
 #------------------------------------
 

--- a/gltf2glb.py
+++ b/gltf2glb.py
@@ -105,9 +105,9 @@ def main():
 	parser.add_argument("-c", "--cesium", action="store_true", \
 						help="sets the old body buffer name for compatibility with Cesium [UNNECESSARY - DEPRECATED]")
 	parser.add_argument("-i", "--i3dm", type=str, \
-	                    help="Export i3dm, with optional path to JSON instance table data")
+	                    help="Export i3dm, with required path to input JSON instance table data. Supports only embedded GLTFs")
 	parser.add_argument("-b", "--b3dm", type=str, \
-	                    help="Export b3dm, with optional path to JSON batch table data")
+	                    help="Export b3dm, with optional path to input JSON batch table data")
 	parser.add_argument("-o", "--output", required=False, default=None,
 	                    help="Optional output path (defaults to the path of the input file")
 	parser.add_argument("filename")
@@ -234,12 +234,24 @@ def main():
 		if len(args.b3dm):
 			with open(args.b3dm, 'r') as f:
 				b3dm_json = json.loads(f.read())
-				b3dm_encoder.loadJSONBatch(b3dm_json, False)
+			b3dm_encoder.loadJSONBatch(b3dm_json, False)
 
 		with open(fname_out, 'w') as f:
 			f.write(b3dm_encoder.writeBinary(glb))
+
 	elif args.i3dm != None:
-		raise NotImplementedError
+		glb = encoder.exportString()
+		i3dm_encoder = i3dm.I3DM()
+		if not(len(args.i3dm)):
+			raise ValueError("-i/--i3dm requires a JSON instance table")
+		else:
+			with open(args.i3dm, 'r') as f:
+				i3dm_json = json.loads(f.read())
+			i3dm_encoder.loadJSONInstances(i3dm_json)
+
+		with open(fname_out, 'w') as f:
+			f.write(i3dm_encoder.writeBinary(glb, True))		# Second arg: embed gltf
+
 	else:
 		encoder.export(fname_out)
 

--- a/i3dm.py
+++ b/i3dm.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python
 
-#--------------------------------------------
+#--------------------------------------------------------
 # i3dm.py: Component of GLTF to GLB converter
-# (c) 2016 Geopipe, Inc.
+# (c) 2016 - 2019 Geopipe, Inc.
 # All rights reserved. See LICENSE.
-#--------------------------------------------
+#
+# Source spec: see
+# https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/
+#       master/specification/TileFormats/Instanced3DModel
+# - Feature table: contains the actual information about
+#   the instances to be created.
+# - Batch table: may contain information about separate
+#   units that can be declaratively styled within the
+#   single model that is instanced, but we expect this to
+#   be used in a relative minority of the use cases.
+#---------------------------------------------------------
 
 import struct
+import argparse
+import json
+
 from batchtable import BatchTable
 from featuretable import FeatureTable
 
@@ -16,14 +29,17 @@ I3DM_HEADER_LEN = 32
 
 class I3DM:
 	def __init__(self):
-		self.batch_table = InstanceTable()
+		self.batch_table = BatchTable()
 		self.feature_table = FeatureTable()
 		self.gltf_bin = bytearray()
 
 	def loadJSONBatch(self, data_in, object_wise = True):
 		self.batch_table.loadJSONBatch(data_in, object_wise)
 
-	def loadJSONFeature(self, data_in, object_wise = True):
+	def loadJSONInstances(self, i3dm_json, object_wise = True):
+		self.loadJSONFeatures(i3dm_json, object_wise)
+
+	def loadJSONFeatures(self, data_in, object_wise = True):
 		self.feature_table.loadJSONBatch(data_in, object_wise)
 
 	# If embed_gltf is false, gltf_bin is a URI string instead of GLTF data
@@ -32,9 +48,10 @@ class I3DM:
 
 		# Add the required field BATCH_LENGTH to the feature table,
 		# as well as any other required globals
-		num_batches = max(num_batches, self.batch_table.getNumInstances())
-		self.feature_table.addGlobal('INSTANCES_LENGTH', num_batches)
+		num_batch_features = max(num_batches, self.batch_table.getNumFeatures())
+		self.feature_table.addGlobal('BATCH_LENGTH', num_batch_features)
 		num_feature_features = max(num_feature_features, self.feature_table.getNumFeatures())
+		self.feature_table.addGlobal('INSTANCES_LENGTH', num_feature_features)
 
 		self.batch_table.finalize()
 		self.feature_table.finalize()
@@ -43,11 +60,11 @@ class I3DM:
 		output = self.writeHeader(gltf_bin, num_batch_features, num_feature_features)
 
 		# Add the feature table JSON to the output
-		feature_json = self.feature_table.getBatchJSON()
+		feature_json = self.feature_table.getFeatureJSON()
 		output.extend(feature_json)
 
 		# Add the feature table binary to the output
-		feature_bin  = self.feature_table.getBatchBin()
+		feature_bin  = self.feature_table.getFeatureBin()
 		output.extend(feature_bin)
 
 		# Add the batch table JSON to the output
@@ -64,7 +81,7 @@ class I3DM:
 		return output
 
 	# If embed_gltf is false, gltf_bin is a URI string instead of GLTF data
-	def writeHeader(self, gltf_bin, num_feature_features, num_batch_features):
+	def writeHeader(self, gltf_bin, num_batch_features, num_feature_features):
 		len_feature_json = len(self.feature_table.getBatchJSON())
 		len_feature_bin  = len(self.feature_table.getBatchBin())
 		len_batch_json   = len(self.batch_table.getBatchJSON())

--- a/i3dm.py
+++ b/i3dm.py
@@ -146,3 +146,31 @@ class I3DM:
 		calc_len = struct.calcsize(fmt)
 		self.offset += calc_len
 		return struct.unpack(fmt, data[self.offset - calc_len : self.offset])[0]
+
+def main():
+	""" Generates an i3dm file from a glb plus JSON"""
+
+	# Parse options and get results
+	parser = argparse.ArgumentParser(description='Converts GLTF to GLB')
+	parser.add_argument("-i", "--i3dm", type=str, required=True, \
+	                    help="Export i3dm, with required path to input JSON instance table data. Supports only embedded GLBs")
+	parser.add_argument("-g", "--glb", type=str, required=True, \
+	                    help="GLB file to instance and embed in the output i3dm file")
+	parser.add_argument("-o", "--output", required=True, \
+	                    help="Output i3dm path")
+	args = parser.parse_args()
+	
+	i3dm_encoder = I3DM()
+	if not(len(args.i3dm)):
+		raise ValueError("-i/--i3dm requires a JSON instance table")
+	else:
+		with open(args.i3dm, 'r') as f:
+			i3dm_json = json.loads(f.read())
+		i3dm_encoder.loadJSONInstances(i3dm_json)
+
+	with open(args.glb, 'rb') as glb:
+		with open(args.output, 'wb') as f:
+			f.write(i3dm_encoder.writeBinary(glb.read(), True))		# Second arg: embed gltf
+
+if __name__ == "__main__":
+	main()

--- a/i3dm.py
+++ b/i3dm.py
@@ -8,12 +8,124 @@
 
 import struct
 from batchtable import BatchTable
+from featuretable import FeatureTable
 
+I3DM_MAGIC = 'i3dm'
 I3DM_VERSION = 1
-I3DM_HEADER_LEN = 24
+I3DM_HEADER_LEN = 32
 
-class I3DM(BatchTable):
+class I3DM:
 	def __init__(self):
-		BatchTable.init(self)
+		self.batch_table = InstanceTable()
+		self.feature_table = FeatureTable()
 		self.gltf_bin = bytearray()
-		raise NotImplementedError
+
+	def loadJSONBatch(self, data_in, object_wise = True):
+		self.batch_table.loadJSONBatch(data_in, object_wise)
+
+	def loadJSONFeature(self, data_in, object_wise = True):
+		self.feature_table.loadJSONBatch(data_in, object_wise)
+
+	# If embed_gltf is false, gltf_bin is a URI string instead of GLTF data
+	def writeBinary(self, gltf_bin, embed_gltf = True, num_batches = 0, num_feature_features = 0):
+		self.embed_gltf = embed_gltf
+
+		# Add the required field BATCH_LENGTH to the feature table,
+		# as well as any other required globals
+		num_batches = max(num_batches, self.batch_table.getNumInstances())
+		self.feature_table.addGlobal('INSTANCES_LENGTH', num_batches)
+		num_feature_features = max(num_feature_features, self.feature_table.getNumFeatures())
+
+		self.batch_table.finalize()
+		self.feature_table.finalize()
+
+		# Generate the header
+		output = self.writeHeader(gltf_bin, num_batch_features, num_feature_features)
+
+		# Add the feature table JSON to the output
+		feature_json = self.feature_table.getBatchJSON()
+		output.extend(feature_json)
+
+		# Add the feature table binary to the output
+		feature_bin  = self.feature_table.getBatchBin()
+		output.extend(feature_bin)
+
+		# Add the batch table JSON to the output
+		batch_json = self.batch_table.getBatchJSON()
+		output.extend(batch_json)
+
+		# Add the batch table binary to the output
+		batch_bin  = self.batch_table.getBatchBin()
+		output.extend(batch_bin)
+
+		# Add the GLTF model body to the output
+		output.extend(gltf_bin)
+
+		return output
+
+	# If embed_gltf is false, gltf_bin is a URI string instead of GLTF data
+	def writeHeader(self, gltf_bin, num_feature_features, num_batch_features):
+		len_feature_json = len(self.feature_table.getBatchJSON())
+		len_feature_bin  = len(self.feature_table.getBatchBin())
+		len_batch_json   = len(self.batch_table.getBatchJSON())
+		len_batch_bin    = len(self.batch_table.getBatchBin())
+
+		length = I3DM_HEADER_LEN + \
+		         len_feature_json + len_feature_bin + \
+		         len_batch_json   + len_batch_bin + \
+		         len(gltf_bin)
+	
+		output = bytearray()
+		output.extend(I3DM_MAGIC)
+		output.extend(struct.pack('<I', I3DM_VERSION))
+		output.extend(struct.pack('<I', length))
+		output.extend(struct.pack('<I', len_feature_json))
+		output.extend(struct.pack('<I', len_feature_bin))
+		output.extend(struct.pack('<I', len_batch_json))
+		output.extend(struct.pack('<I', len_batch_bin))
+		output.extend(struct.pack('<I', 0 if self.embed_gltf else 1))
+	
+		# Sanity check
+		if (len(output) != I3DM_HEADER_LEN):
+			raise ValueError("Incorrect i3dm header length")
+	
+		return output
+
+	def readBinary(self, data):
+		self.offset = 0
+		self.readHeader(data)			 # What it says on the tin
+
+		# Now grab the feature table, batch table, and GLB
+		self.feature_json = self.unpackString(data, self.len_feature_json)
+		self.feature_bin  = self.unpackString(data, self.len_feature_bin)
+		self.batch_json = self.unpackString(data, self.len_batch_json)
+		self.batch_bin  = self.unpackString(data, self.len_batch_bin)
+
+		self.gltf_bin = self.unpackString(data, self.length - self.offset)
+
+	def readHeader(self, data):
+		self.magic = self.unpack('4s', data)
+		self.version = self.unpack('<I', data)
+
+		if self.magic != I3DM_MAGIC or self.version > I3DM_VERSION:
+			print("Unrecognized magic %s or bad version %d" % (self.magic, self.version))
+			raise IOError
+
+		self.length           = self.unpack('<I', data)
+		self.len_feature_json = self.unpack('<I', data)
+		self.len_feature_bin  = self.unpack('<I', data)
+		self.len_batch_json   = self.unpack('<I', data)
+		self.len_batch_bin    = self.unpack('<I', data)
+		self.embed_gltf       = self.unpack('<I', data)
+
+	def getGLTFBin(self):
+		return self.gltf_bin
+
+	def unpackString(self, data, length):
+		self.offset += length
+		return data[self.offset - length : self.offset]
+
+	def unpack(self, fmt, data):
+		calc_len = struct.calcsize(fmt)
+		self.offset += calc_len
+		return struct.unpack(fmt, data[self.offset - calc_len : self.offset])[0]

--- a/instancetable.py
+++ b/instancetable.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+#--------------------------------------------------
+# instancetable.py: Component of GLTF to GLB converter
+# Currently a placeholder copy of BatchTable
+# (c) 2017 Geopipe, Inc.
+# All rights reserved. See LICENSE.
+#--------------------------------------------------
+
+import struct
+import json
+from batchtable import BatchTable
+
+class InstanceTable(BatchTable):
+	def __init__(self):
+		BatchTable.__init__(self)

--- a/packglb.py
+++ b/packglb.py
@@ -21,9 +21,9 @@ def main():
 	# Parse options and get results
 	parser = argparse.ArgumentParser(description='Converts GLTF to GLB')
 	parser.add_argument("-i", "--i3dm", type=str, \
-	                    help="Export i3dm, with optional path to JSON instance table data")
+	                    help="Export i3dm, with required path to input JSON instance table data. Supports only embedded GLTFs")
 	parser.add_argument("-b", "--b3dm", type=str, \
-	                    help="Export b3dm, with optional path to JSON batch table data")
+	                    help="Export b3dm, with optional path to input JSON batch table data")
 	parser.add_argument("-o", "--output", required=False, default=None, \
 	                    help="Optional output path (defaults to the path of the input file")
 	parser.add_argument("-u", "--unpack", action='store_true', \
@@ -75,8 +75,19 @@ def main():
 
 		with open(fname_out, 'w') as f:
 			f.write(b3dm_encoder.writeBinary(glb))
+
 	elif args.i3dm != None:
-		raise NotImplementedError
+		i3dm_encoder = i3dm.I3DM()
+		if not(len(args.i3dm)):
+			raise ValueError("-i/--i3dm requires a JSON instance table")
+		else:
+			with open(args.i3dm, 'r') as f:
+				i3dm_json = json.loads(f.read())
+			i3dm_encoder.loadJSONInstances(i3dm_json, False)
+
+		with open(fname_out, 'w') as f:
+			f.write(i3dm_encoder.writeBinary(glb, True))		# Second arg: embed gltf
+
 	else:
 		# This is kinda pointless
 		with open(fname_out, 'w') as f:


### PR DESCRIPTION
Add support for generating CesiumJS `i3dm` files from a JSON describing the instances, and a GLB file to instance. Poorly documented sample instance JSON:
```
[
	{
		"POSITION": [0.0, 0.0, 0.0]
	},
	{
		"POSITION": [10.0, 20.0, 0.0]
	},
	{
		"POSITION": [10.0, 0.0, 0.0]
	},
	{
		"POSITION": [0.0, 0.0, 15.0]
	}
]
```

Just for fun, assigning to @elfprince13 for review (feel free to decline to do so). Tested functioning with CesiumJS for simple instancing like the above. Future work includes documenting the expected JSON format ~better~.