### PR TITLE
Fix cmpt generation with RGB data

### DIFF
--- a/batchtable.py
+++ b/batchtable.py
@@ -91,7 +91,7 @@ class BatchTable:
 
 	""" A few utilities """
 	def nestedListToBin(self, val, val_type):
-		val_codes = {'f32' : 'f','u16':'H'}
+		val_codes = {'f32' : 'f', 'u16' : 'H', 'u8' : 'B'}
 		if val_type not in val_codes:
 			raise TypeError("Don't know how to pack type '%s'" % val_type)
 		else:


### PR DESCRIPTION
RGB data is stored as unsigned chars, which BatchTable currently does not handle, resulting in GPF to CMPT conversion crashing on files with RGB data